### PR TITLE
Update k8s deployment api version to apps/v1

### DIFF
--- a/deploy/cert-manager-webhook-ovh/templates/deployment.yaml
+++ b/deploy/cert-manager-webhook-ovh/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "cert-manager-webhook-ovh.fullname" . }}


### PR DESCRIPTION
The api version of the Kubernetes deployment manifest is [deprecated](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/) and cannot be deployed to Kubernetes cluster anymore. Updated api version to `apps/v1`.