### PR TITLE
Add release.Namespace in meta and update api

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ If you customized the installation of cert-manager, you may need to also set the
 4. Create a certificate issuer:
 
     ```yaml
-    apiVersion: certmanager.k8s.io/v1alpha1
+    apiVersion: cert-manager.io/v1alpha2
     kind: Issuer
     metadata:
       name: letsencrypt
@@ -92,7 +92,7 @@ If you customized the installation of cert-manager, you may need to also set the
 Issue a certificate:
 
 ```yaml
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   name: example-com

--- a/deploy/cert-manager-webhook-ovh/Chart.yaml
+++ b/deploy/cert-manager-webhook-ovh/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.1.0"
 description: OVH DNS cert-manager ACME webhook
 name: cert-manager-webhook-ovh
-version: 0.1.0
+version: 0.2.0

--- a/deploy/cert-manager-webhook-ovh/templates/deployment.yaml
+++ b/deploy/cert-manager-webhook-ovh/templates/deployment.yaml
@@ -1,7 +1,8 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "cert-manager-webhook-ovh.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ include "cert-manager-webhook-ovh.name" . }}
     chart: {{ include "cert-manager-webhook-ovh.chart" . }}

--- a/deploy/cert-manager-webhook-ovh/templates/rbac.yaml
+++ b/deploy/cert-manager-webhook-ovh/templates/rbac.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "cert-manager-webhook-ovh.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ include "cert-manager-webhook-ovh.name" . }}
     chart: {{ include "cert-manager-webhook-ovh.chart" . }}

--- a/deploy/cert-manager-webhook-ovh/templates/service.yaml
+++ b/deploy/cert-manager-webhook-ovh/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "cert-manager-webhook-ovh.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ include "cert-manager-webhook-ovh.name" . }}
     chart: {{ include "cert-manager-webhook-ovh.chart" . }}


### PR DESCRIPTION
This is tested with Kubernetes `1.17.4` and cert-manager `0.14.1`.

* Add release.Namespace in meta

Adding release.Namespace in meta fixes issues when rendering template with 'helm template --namespace'. Without it, the rendered templates do not have the namespace defined which is problematic when using a gitops approach. This is also a requirement for a tool like Spinnaker.

* update api versions

Use cert-manager.io/v1alpha2 and update deprecated API for Deployment

* Bump to version 0.2.0

Signed-off-by: lcavajani <lcavajani@suse.com>