### PR TITLE
fix #5, base64 secret was parsed with an ending \n

### DIFF
--- a/main.go
+++ b/main.go
@@ -142,7 +142,7 @@ func (s *ovhDNSProviderSolver) secret(ref corev1.SecretKeySelector, namespace st
 	if !ok {
 		return "", fmt.Errorf("key not found %q in secret '%s/%s'", ref.Key, namespace, ref.Name)
 	}
-	return string(bytes), nil
+	return strings.TrimSuffix(string(bytes), "\n"), nil
 }
 
 // Present is responsible for actually presenting the DNS record with the


### PR DESCRIPTION
When I was executing the test suite I encountered the same issue as described in issue #5. Base64 secret was parsed with an ending \n.
I don't know what happened under the hood (I tried with or without breaking line in the Yaml, I tested different line separators for the Yaml file... This seems to be linked with the way base64 decoding is done.).