### PR TITLE
HTTP_PROXY proxy support

### DIFF
--- a/deploy/cert-manager-webhook-ovh/templates/deployment.yaml
+++ b/deploy/cert-manager-webhook-ovh/templates/deployment.yaml
@@ -31,6 +31,18 @@ spec:
           env:
             - name: GROUP_NAME
               value: {{ .Values.groupName | quote }}
+            {{- with .Values.http_proxy }}
+            - name: HTTP_PROXY
+              value: {{ . }}
+            {{- end }}
+            {{- with .Values.https_proxy }}
+            - name: HTTPS_PROXY
+              value: {{ . }}
+            {{- end }}
+            {{- with .Values.no_proxy }}
+            - name: NO_PROXY
+              value: {{ . }}
+            {{- end }}
           ports:
             - name: https
               containerPort: 443

--- a/deploy/cert-manager-webhook-ovh/values.yaml
+++ b/deploy/cert-manager-webhook-ovh/values.yaml
@@ -20,6 +20,11 @@ image:
 nameOverride: ""
 fullnameOverride: ""
 
+# Use these variables to configure the HTTP_PROXY environment variables
+# http_proxy: "http://proxy:8080"
+# https_proxy: "http://proxy:8080"
+# no_proxy: 127.0.0.1,localhost,10.0.0.0/8
+
 service:
   type: ClusterIP
   port: 443


### PR DESCRIPTION
This pull request is to allow deployment behind a HTTP proxy to communicate with the OVH api through a user defined proxy.
Thos works by simply creating environment variables named `HTTP_PROXY, `HTTPS_PROXY` and `NO_PROXY` as part of the deployment.

The changes presented in this PR are directly borrowed from `cert-manager` v1.6.1 to make things more consistent for the end user.

I've done a test and it worked for me as expected.