### PR TITLE
Updating the certificate object in the template to include full date value in duration attribute

### DIFF
--- a/deploy/cert-manager-webhook-ovh/Chart.yaml
+++ b/deploy/cert-manager-webhook-ovh/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.3.0"
 description: OVH DNS cert-manager ACME webhook
 name: cert-manager-webhook-ovh
-version: 0.3.0
+version: 0.3.1

--- a/deploy/cert-manager-webhook-ovh/templates/pki.yaml
+++ b/deploy/cert-manager-webhook-ovh/templates/pki.yaml
@@ -29,7 +29,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   secretName: {{ include "cert-manager-webhook-ovh.rootCACertificate" . }}
-  duration: 43800h # 5y
+  duration: 43800h0m0s # 5y
   issuerRef:
     name: {{ include "cert-manager-webhook-ovh.selfSignedIssuer" . }}
   commonName: "ca.cert-manager-webhook-ovh.cert-manager"
@@ -67,7 +67,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   secretName: {{ include "cert-manager-webhook-ovh.servingCertificate" . }}
-  duration: 8760h # 1y
+  duration: 8760h0m0s # 1y
   issuerRef:
     name: {{ include "cert-manager-webhook-ovh.rootCAIssuer" . }}
   dnsNames:


### PR DESCRIPTION
When using ArgoCD to deploy cert-manager-webhook-ovh the certificate objects for the OVH CA and TLS are always out of sync. This due to mismatch between the duration declared by the helm template and the certificate object that is created. 

I have updated the template objects to reflect what the value would be when the certificate objects is created. 