### PR TITLE
docs: Add link HTTP query arg way of specifying access rights for OVH creds

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If you customized the installation of cert-manager, you may need to also set the
 
 ## Issuer
 
-1. [Create a new OVH API key](https://docs.ovh.com/gb/en/customer/first-steps-with-ovh-api/) with the following rights by opening this link and signing in: https://auth.eu.ovhcloud.com/api/createToken?GET=/domain/zone/*&PUT=/domain/zone/*&POST=/domain/zone/*&DELETE=/domain/zone/* 
+1. [Create a new OVH API key](https://docs.ovh.com/gb/en/customer/first-steps-with-ovh-api/) with the following rights by opening [this link](https://auth.eu.ovhcloud.com/api/createToken?GET=/domain/zone/*&PUT=/domain/zone/*&POST=/domain/zone/*&DELETE=/domain/zone/*) and signing in:
     * `GET /domain/zone/*`
     * `PUT /domain/zone/*`
     * `POST /domain/zone/*`

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If you customized the installation of cert-manager, you may need to also set the
 
 ## Issuer
 
-1. [Create a new OVH API key](https://docs.ovh.com/gb/en/customer/first-steps-with-ovh-api/) with the following rights:
+1. [Create a new OVH API key](https://docs.ovh.com/gb/en/customer/first-steps-with-ovh-api/) with the following rights by opening this link and signing in: https://auth.eu.ovhcloud.com/api/createToken?GET=/domain/zone/*&PUT=/domain/zone/*&POST=/domain/zone/*&DELETE=/domain/zone/* 
     * `GET /domain/zone/*`
     * `PUT /domain/zone/*`
     * `POST /domain/zone/*`


### PR DESCRIPTION
This seems like an easy and foolproof way to generate creds with the right permissions. I like it